### PR TITLE
Java 20 compat, module-info.java

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,1 @@
--DcommonConfig.compiler.profile=jdk7
+-DcommonConfig.compiler.profile=jdk20

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.7/apache-maven-3.8.7-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.5/apache-maven-3.9.5-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ providing well-defined modes of operation which includes:
 
 All this is achieved by only adding [HKDF](https://en.wikipedia.org/wiki/HKDF) as additional building block.
 
-The code is compiled with target [Java 7](https://en.wikipedia.org/wiki/Java_version_history#Java_SE_7) to be compatible with most [_Android_](https://www.android.com/) versions as well as normal Java applications.
+The code is compiled with target [Java 20](https://en.wikipedia.org/wiki/Java_version_history#Java_SE_7) to leverage [Java's module system](https://www.oracle.com/corporate/features/understanding-java-9-modules.html) and adopt new improvements in the JDK. 
+Please refer to versions 0.6.0 and below for Java 7 compatibility.
 
 _Note, that this project is ongoing research and may not be ready for prime-time yet as it requires more feedback from the cryptographic community._
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>bkdf</artifactId>
-    <version>0.6.0</version>
+    <version>1.0.0</version>
     <packaging>jar</packaging>
 
     <name>BCrypt Key Derivation Function</name>
@@ -26,9 +26,11 @@
         <!-- SonarQube Config -->
         <sonar.organization>patrickfav</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+<!--        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>-->
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
         <sonar.language>java</sonar.language>
+        <maven.compiler.source>20</maven.compiler.source>
+        <maven.compiler.target>20</maven.compiler.target>
     </properties>
 
     <build>
@@ -49,10 +51,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.jacoco</groupId>-->
+<!--                <artifactId>jacoco-maven-plugin</artifactId>-->
+<!--                <version>0.8.8</version>-->
+<!--            </plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jarsigner-plugin</artifactId>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module at.favre.lib {
+    requires at.favre.lib.hkdf;
+    requires at.favre.lib.bytes;
+    requires bcrypt;
+    exports at.favre.lib.crypto.bkdf;
+}


### PR DESCRIPTION
Hello @patrickfav,

This PR is aiming at giving some support to this similar PR w/ Blake2B and @kjetilkl: https://github.com/rfksystems/blake2b/pull/2

The original work for Crypt4GH is happening here: https://github.com/uio-bmi/crypt4gh/issues/85#issuecomment-1804468714

The motivation for the changes comprised here is well described in that description, so I'll not repeat it here.

A particularity of your library is that I couldn't (easily) migrate JaCoCo, there's a long string of errors if enabled. Tests pass for now, so if you can review the PR and advise I can revisit and try to fix that one for you?

I'll make similar modifications to your `bcrypt` dependant library if you are happy with those in here?